### PR TITLE
Removed ampersand (&) from generated server passwords

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -699,7 +699,7 @@ func generatePassword(strlen int) string {
 	*/
 	// adapted from http://siongui.github.io/2015/04/13/go-generate-random-string/
 	rand.Seed(time.Now().UTC().UnixNano())
-	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIFJKLMNOPQRSTUVWXYZ0123456789!@#$*&()_"
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIFJKLMNOPQRSTUVWXYZ0123456789!@#$*()_"
 	result := make([]byte, strlen)
 	for i := 0; i < strlen; i++ {
 		result[i] = chars[rand.Intn(len(chars))]


### PR DESCRIPTION
The `&` character is a disallowed character for server passwords in CLC. If it's included in the generated password, the server build will fail with a `The field password contains invalid special characters.`
